### PR TITLE
Bip39 bip44 updates

### DIFF
--- a/Strike/Bip44.swift
+++ b/Strike/Bip44.swift
@@ -23,10 +23,10 @@ struct Ed25519HierachicalPrivateKey {
         self.chainCode = SymmetricKey(data: data.suffix(32))
     }
     
-    public static func fromSeedPhrase(words: [String]) throws -> Ed25519HierachicalPrivateKey {
+    public static func fromRootSeed(rootSeed: [UInt8]) throws -> Ed25519HierachicalPrivateKey {
         var derivedKey = try Ed25519HierachicalPrivateKey(
-            data: try Data(HMAC<SHA512>.authenticationCode(
-                for: Mnemonic(phrase: words).seed,
+            data: Data(HMAC<SHA512>.authenticationCode(
+                for: rootSeed,
                 using: SymmetricKey.init(data: "ed25519 seed".data(using: .utf8)!)
             ))
         )

--- a/StrikeTests/BipTests.swift
+++ b/StrikeTests/BipTests.swift
@@ -31,7 +31,7 @@ class BipTests: XCTestCase {
         let decoder = JSONDecoder()
         let testItems = try! decoder.decode(TestItems.self, from: try Data(contentsOf: url))
         for testItem in testItems.items {
-            let ed25519PrivateKey = try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: testItem.mnemonic.components(separatedBy: " "))
+            let ed25519PrivateKey = try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: testItem.mnemonic.components(separatedBy: " ")).seed)
             // @solana/web3j code which generated this data set represents the private key as the actual private key(32 bytes) appended with public key (another 32 bytes)
             XCTAssertEqual(testItem.privateKeyHex, (ed25519PrivateKey.privateKey.rawRepresentation + ed25519PrivateKey.privateKey.publicKey.rawRepresentation).toHexString().lowercased())
             XCTAssertEqual(testItem.publicKeyBase58, Base58.encode(ed25519PrivateKey.privateKey.publicKey.rawRepresentation.bytes))
@@ -43,12 +43,14 @@ class BipTests: XCTestCase {
         // generate a new 24 word phrase and generate key
         let words = Mnemonic(strength: 256).phrase
         XCTAssertEqual(words.count, 24)
-        let hdKey = try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: words)
+        let rootSeed = try Mnemonic(phrase: words).seed
+        let hdKey = try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: rootSeed)
         let signature = try hdKey.privateKey.signature(for: "Hello World".data(using: .utf16)!)
         
         // regenerate from same set and verify keys match
-        let hdKey2 = try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: words)
+        let hdKey2 = try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: words).seed)
         XCTAssertEqual(hdKey.privateKey.rawRepresentation.toHexString(), hdKey2.privateKey.rawRepresentation.toHexString())
+        XCTAssertTrue(hdKey2.privateKey.publicKey.isValidSignature(signature, for: "Hello World".data(using: .utf16)!))
     }
     
     func testMnemonic() throws {
@@ -71,29 +73,29 @@ class BipTests: XCTestCase {
     
     func testVerificationError() throws {
         let originalPhrase = "echo flat forget radio apology old until elite keep fine clock parent cereal ticket dutch whisper flock junior pet six uphold gorilla trend spare"
-        let hdKey = try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: originalPhrase.components(separatedBy: " "))
+        let hdKey = try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: originalPhrase.components(separatedBy: " ")).seed)
 
         // radio and forget are flipped - Mnenomics implementation detects words are transposed based on checksum validations
         let transposedWords = "echo flat radio forget apology old until elite keep fine clock parent cereal ticket dutch whisper flock junior pet six uphold gorilla trend spare"
-        XCTAssertThrowsError(try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: transposedWords.components(separatedBy: " "))) { error in
+        XCTAssertThrowsError(try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: transposedWords.components(separatedBy: " ")).seed)) { error in
             XCTAssertEqual(error as! Mnemonic.Error, Mnemonic.Error.invalidMnemonic)
         }
        
         // change the word old to new (which is not a valid word)
         let wrongWords = "echo flat forget radio apology new until elite keep fine clock parent cereal ticket dutch whisper flock junior pet six uphold gorilla trend spare"
-        XCTAssertThrowsError(try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: wrongWords.components(separatedBy: " "))) { error in
+        XCTAssertThrowsError(try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: wrongWords.components(separatedBy: " ")).seed)) { error in
             XCTAssertEqual(error as! Mnemonic.Error, Mnemonic.Error.invalidMnemonic)
         }
        
         // change forget to forged
         let incorrectSpelledWords = "echo flat forged radio apology old until elite keep fine clock parent cereal ticket dutch whisper flock junior pet six uphold gorilla trend spare"
-        XCTAssertThrowsError(try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: incorrectSpelledWords.components(separatedBy: " "))) { error in
+        XCTAssertThrowsError(try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: incorrectSpelledWords.components(separatedBy: " ")).seed)) { error in
             XCTAssertEqual(error as! Mnemonic.Error, Mnemonic.Error.invalidMnemonic)
         }
        
         // valid phrase for a different key
         let otherValidPhrase = "refuse hedgehog nerve insect silent sunset regret slush walnut illness visit slim advance mobile shrug initial grid topple inch okay bunker marriage bench chapter"
-        let hdKey2 = try Ed25519HierachicalPrivateKey.fromSeedPhrase(words: otherValidPhrase.components(separatedBy: " "))
+        let hdKey2 = try Ed25519HierachicalPrivateKey.fromRootSeed(rootSeed: try Mnemonic(phrase: otherValidPhrase.components(separatedBy: " ")).seed)
         XCTAssertNotEqual(hdKey.privateKey.rawRepresentation.toHexString(), hdKey2.privateKey.rawRepresentation.toHexString())
    }
     


### PR DESCRIPTION
- pass the root seed as oppose to words
- root seed can be saved so we can derive other key types as needed from this seed