### PR TITLE
Sign password reset approval according to backend expectations

### DIFF
--- a/Strike/Models/Solana/ApprovalDispositionRequest+SolanaSignable.swift
+++ b/Strike/Models/Solana/ApprovalDispositionRequest+SolanaSignable.swift
@@ -223,7 +223,7 @@ extension StrikeApi.ApprovalDispositionRequest: SolanaSignable {
     func signableData(approverPublicKey: String) throws -> Data {
         switch requestType {
         case .passwordReset(let request):
-            return "".data(using: .utf8)!
+            return requestID.data(using: .utf8)!
         case .acceptVaultInvitation(let request):
             return request.vaultName.data(using: .utf8)!
         case .loginApproval(let request):

--- a/StrikeTests/StrikeTests.swift
+++ b/StrikeTests/StrikeTests.swift
@@ -705,7 +705,7 @@ class StrikeTests: XCTestCase {
         case .passwordReset:
             XCTAssertEqual(
                 String(decoding: try approvalDispositionRequest.signableData(approverPublicKey: "GYFxPGjuBXYKg1S91zgpVZCLP4guLGRho27bTAkAzjVL"), as: UTF8.self),
-                ""
+                request.id
             )
         default:
             XCTFail("should not get here")


### PR DESCRIPTION
In https://github.com/StrikeProtocols/prime/pull/351 we expect request id to be signed for password resets.