### PR TITLE
Rework Bitcoin and Ethereum wallet creation

### DIFF
--- a/Strike.xcodeproj/project.pbxproj
+++ b/Strike.xcodeproj/project.pbxproj
@@ -88,8 +88,8 @@
 		3DB7F9C026D6C2CD00A49B4E /* UnknownRequestRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB7F9BF26D6C2CD00A49B4E /* UnknownRequestRow.swift */; };
 		3DB995F627EB71EE005655F0 /* SignerUpdateRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995F527EB71ED005655F0 /* SignerUpdateRow.swift */; };
 		3DB995F827EB71FA005655F0 /* SignerUpdateDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995F727EB71FA005655F0 /* SignerUpdateDetails.swift */; };
-		3DB995FB27EB7997005655F0 /* AccountCreationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995FA27EB7997005655F0 /* AccountCreationRow.swift */; };
-		3DB995FD27EB79A4005655F0 /* AccountCreationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995FC27EB79A4005655F0 /* AccountCreationDetails.swift */; };
+		3DB995FB27EB7997005655F0 /* WalletCreationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995FA27EB7997005655F0 /* WalletCreationRow.swift */; };
+		3DB995FD27EB79A4005655F0 /* WalletCreationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995FC27EB79A4005655F0 /* WalletCreationDetails.swift */; };
 		3DB995FF27EE1804005655F0 /* BiometryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB995FE27EE1804005655F0 /* BiometryError.swift */; };
 		3DB9960127EE1A1B005655F0 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB9960027EE1A1B005655F0 /* Data+Extensions.swift */; };
 		3DBC44E3280F17660016E1AB /* LoginRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBC44E2280F17660016E1AB /* LoginRow.swift */; };
@@ -255,8 +255,8 @@
 		3DB7F9BF26D6C2CD00A49B4E /* UnknownRequestRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownRequestRow.swift; sourceTree = "<group>"; };
 		3DB995F527EB71ED005655F0 /* SignerUpdateRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerUpdateRow.swift; sourceTree = "<group>"; };
 		3DB995F727EB71FA005655F0 /* SignerUpdateDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerUpdateDetails.swift; sourceTree = "<group>"; };
-		3DB995FA27EB7997005655F0 /* AccountCreationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationRow.swift; sourceTree = "<group>"; };
-		3DB995FC27EB79A4005655F0 /* AccountCreationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationDetails.swift; sourceTree = "<group>"; };
+		3DB995FA27EB7997005655F0 /* WalletCreationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCreationRow.swift; sourceTree = "<group>"; };
+		3DB995FC27EB79A4005655F0 /* WalletCreationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCreationDetails.swift; sourceTree = "<group>"; };
 		3DB995FE27EE1804005655F0 /* BiometryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometryError.swift; sourceTree = "<group>"; };
 		3DB9960027EE1A1B005655F0 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		3DBC44E2280F17660016E1AB /* LoginRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRow.swift; sourceTree = "<group>"; };
@@ -648,8 +648,8 @@
 		3DB995F927EB74E9005655F0 /* AccountCreation */ = {
 			isa = PBXGroup;
 			children = (
-				3DB995FA27EB7997005655F0 /* AccountCreationRow.swift */,
-				3DB995FC27EB79A4005655F0 /* AccountCreationDetails.swift */,
+				3DB995FA27EB7997005655F0 /* WalletCreationRow.swift */,
+				3DB995FC27EB79A4005655F0 /* WalletCreationDetails.swift */,
 			);
 			path = AccountCreation;
 			sourceTree = "<group>";
@@ -960,7 +960,7 @@
 				6CCDBD5828EF8BBD00BBB5B6 /* AdditionalKeyRegistration.swift in Sources */,
 				3D6334EC2885C299002CEC5A /* PenAndPaperConfirm.swift in Sources */,
 				3DBF9DC326E000CC00D7683E /* EmptyApprovalRequestsList.swift in Sources */,
-				3DB995FB27EB7997005655F0 /* AccountCreationRow.swift in Sources */,
+				3DB995FB27EB7997005655F0 /* WalletCreationRow.swift in Sources */,
 				3D11A60327580D3F008C03B1 /* DAppScan.swift in Sources */,
 				3DB995FF27EE1804005655F0 /* BiometryError.swift in Sources */,
 				3DBF9DAF26DE7A0E00D7683E /* ViewRouter.swift in Sources */,
@@ -997,7 +997,7 @@
 				3DAA26F6262F5156000F453D /* DestructiveButtonStyle.swift in Sources */,
 				3D311D57260A3A1A007A0B98 /* MockAuthProvider.swift in Sources */,
 				3D7FFFEF27FA0F88003B3F48 /* DAppTransactionDetails.swift in Sources */,
-				3DB995FD27EB79A4005655F0 /* AccountCreationDetails.swift in Sources */,
+				3DB995FD27EB79A4005655F0 /* WalletCreationDetails.swift in Sources */,
 				3D11520728216FBD007CD43D /* BalanceAccountPolicyRow.swift in Sources */,
 				3D11A60B275851BA008C03B1 /* WalletConnected.swift in Sources */,
 				3D11A60027580CD2008C03B1 /* CaptureController.swift in Sources */,

--- a/Strike/Models/Solana/InitiationRequest+SolanaSignable.swift
+++ b/Strike/Models/Solana/InitiationRequest+SolanaSignable.swift
@@ -12,7 +12,7 @@ extension StrikeApi.InitiationRequest: SolanaSignable {
 
     var opCode: UInt8 {
         switch requestType {
-        case .balanceAccountCreation:
+        case .walletCreation:
             return 3
         case .withdrawalRequest:
             return 7
@@ -103,7 +103,7 @@ extension StrikeApi.InitiationRequest: SolanaSignable {
             }
             
             switch requestType {
-            case .balanceAccountCreation(let request):
+            case .walletCreation(let request):
                 return Data(
                     [opCode] +
                     commonBytes +
@@ -229,8 +229,12 @@ extension StrikeApi.InitiationRequest: SolanaSignable {
     var signingData: SolanaSigningData {
         get throws {
             switch requestType {
-            case .balanceAccountCreation(let request):
-                return request.signingData
+            case .walletCreation(let request):
+                if request.accountInfo.chainName == "Solana" {
+                    return request.signingData!
+                } else {
+                    throw ApprovalError.invalidRequest(reason: "Invalid signing data for Initiation")
+                }
             case .withdrawalRequest(let request):
                 switch request.signingData {
                 case .solana(let signingData):

--- a/Strike/Models/SolanaApprovalRequestType+Language.swift
+++ b/Strike/Models/SolanaApprovalRequestType+Language.swift
@@ -23,9 +23,9 @@ extension SolanaApprovalRequestType {
             return "Remove User"
         case .signersUpdate:
             return "Add User"
-        case .balanceAccountCreation(let accountCreation) where accountCreation.accountInfo.accountType == .BalanceAccount:
-            return "Add \(accountCreation.accountInfo.chainName ?? "Solana") Wallet"
-        case .balanceAccountCreation:
+        case .walletCreation(let walletCreation) where walletCreation.accountInfo.accountType == .BalanceAccount:
+            return "Add \(walletCreation.accountInfo.chainName ?? "Solana") Wallet"
+        case .walletCreation:
             return "Add Wallet"
         case .balanceAccountNameUpdate:
             return "Rename"

--- a/Strike/Models/SolanaClientModel.swift
+++ b/Strike/Models/SolanaClientModel.swift
@@ -63,9 +63,8 @@ enum LogoType: String, Codable {
 }
 
 
-struct WalletApprovalRequest: Codable, Equatable {
+struct ApprovalRequest: Codable, Equatable {
     let id: String
-    let walletType: WalletType
     let submitterName: String
     let submitterEmail: String
     let submitDate: Date
@@ -77,7 +76,7 @@ struct WalletApprovalRequest: Codable, Equatable {
     let details: SolanaApprovalRequestDetails
 }
 
-extension WalletApprovalRequest {
+extension ApprovalRequest {
     var requestType: SolanaApprovalRequestType {
         switch details {
         case .multisigOpInitiation(_, let requestType):
@@ -94,7 +93,7 @@ enum SolanaApprovalRequestType: Codable, Equatable {
     case conversionRequest(ConversionRequest)
     case wrapConversionRequest(WrapConversionRequest)
     case signersUpdate(SignersUpdate)
-    case balanceAccountCreation(BalanceAccountCreation)
+    case walletCreation(WalletCreation)
     case balanceAccountNameUpdate(BalanceAccountNameUpdate)
     case balanceAccountPolicyUpdate(BalanceAccountPolicyUpdate)
     case balanceAccountSettingsUpdate(BalanceAccountSettingsUpdate)
@@ -125,8 +124,8 @@ enum SolanaApprovalRequestType: Codable, Equatable {
             self = .wrapConversionRequest(try WrapConversionRequest(from: decoder))
         case "SignersUpdate":
             self = .signersUpdate(try SignersUpdate(from: decoder))
-        case "BalanceAccountCreation":
-            self = .balanceAccountCreation(try BalanceAccountCreation(from: decoder))
+        case "WalletCreation":
+            self = .walletCreation(try WalletCreation(from: decoder))
         case "BalanceAccountNameUpdate":
             self = .balanceAccountNameUpdate(try BalanceAccountNameUpdate(from: decoder))
         case "BalanceAccountPolicyUpdate":
@@ -159,9 +158,9 @@ enum SolanaApprovalRequestType: Codable, Equatable {
                 decoder.dateDecodingStrategy = .formatted(.iso8601Full)
                 let signDataParsedJson = try decoder.decode(SignDataApprovalRequestJson.self, from: Data(base64Encoded: request.base64Data)!)
                 switch (signDataParsedJson.data) {
-                case .balanceAccountCreation(var embeddedRequest):
+                case .walletCreation(var embeddedRequest):
                     embeddedRequest.signingData = request.signingData.addDataToSign(dataToSign: request.base64Data)
-                    self = .balanceAccountCreation(embeddedRequest)
+                    self = .walletCreation(embeddedRequest)
                 default:
                     self = .signData(request)
                 }
@@ -188,9 +187,9 @@ enum SolanaApprovalRequestType: Codable, Equatable {
         case .signersUpdate(let signersUpdate):
             try container.encode("SignersUpdate", forKey: .type)
             try signersUpdate.encode(to: encoder)
-        case .balanceAccountCreation(let balanceAccountCreation):
-            try container.encode("BalanceAccountCreation", forKey: .type)
-            try balanceAccountCreation.encode(to: encoder)
+        case .walletCreation(let walletCreation):
+            try container.encode("WalletCreation", forKey: .type)
+            try walletCreation.encode(to: encoder)
         case .balanceAccountNameUpdate(let balanceAccountNameUpdate):
             try container.encode("BalanceAccountNameUpdate", forKey: .type)
             try balanceAccountNameUpdate.encode(to: encoder)
@@ -472,14 +471,14 @@ struct SignersUpdate: Codable, Equatable  {
     var signingData: SolanaSigningData
 }
 
-struct BalanceAccountCreation: Codable, Equatable  {
+struct WalletCreation: Codable, Equatable  {
     var accountSlot: UInt8
     var accountInfo: AccountInfo
     var approvalPolicy: ApprovalPolicy
     var whitelistEnabled: BooleanSetting
     var dappsEnabled: BooleanSetting
     var addressBookSlot: UInt8
-    var signingData: SolanaSigningData
+    var signingData: SolanaSigningData?
 }
 
 struct BalanceAccountNameUpdate: Codable, Equatable  {
@@ -663,6 +662,7 @@ struct SignDataApprovalRequestJson: Codable, Equatable  {
 
 struct NoChainSignature: Codable, Equatable  {
     let signature: String
+    let signedData: String
 }
 
 struct SolanaSignature: Codable, Equatable  {
@@ -752,8 +752,8 @@ extension SolanaApprovalRequestType {
             return request.signingData.nonceAccountAddresses
         case .addressBookUpdate(let request):
             return request.signingData.nonceAccountAddresses
-        case .balanceAccountCreation(let request):
-            return request.signingData.nonceAccountAddresses
+        case .walletCreation(let request):
+            return request.signingData?.nonceAccountAddresses ?? []
         case .balanceAccountNameUpdate(let request):
             return request.signingData.nonceAccountAddresses
         case .balanceAccountPolicyUpdate(let request):
@@ -797,8 +797,8 @@ extension SolanaApprovalRequestType {
             return request.signingData.nonceAccountAddressesSlot
         case .addressBookUpdate(let request):
             return request.signingData.nonceAccountAddressesSlot
-        case .balanceAccountCreation(let request):
-            return request.signingData.nonceAccountAddressesSlot
+        case .walletCreation(let request):
+            return request.signingData?.nonceAccountAddressesSlot ?? 0
         case .balanceAccountNameUpdate(let request):
             return request.signingData.nonceAccountAddressesSlot
         case .balanceAccountPolicyUpdate(let request):
@@ -836,11 +836,10 @@ extension SolanaApprovalRequestType {
 }
 
 #if DEBUG
-extension WalletApprovalRequest {
+extension ApprovalRequest {
     static var sample: Self {
-        WalletApprovalRequest(
+        ApprovalRequest(
             id: "id",
-            walletType: .Solana,
             submitterName: "John Q",
             submitterEmail: "johnq@gmail.com",
             submitDate: Date(),
@@ -854,9 +853,8 @@ extension WalletApprovalRequest {
     }
 
     static var sample2: Self {
-        WalletApprovalRequest(
+        ApprovalRequest(
             id: "id",
-            walletType: .Solana,
             submitterName: "John Q",
             submitterEmail: "johnq@gmail.com",
             submitDate: Date(),

--- a/Strike/Views/ApprovalRequests/AccountCreation/WalletCreationDetails.swift
+++ b/Strike/Views/ApprovalRequests/AccountCreation/WalletCreationDetails.swift
@@ -8,9 +8,9 @@
 import Foundation
 import SwiftUI
 
-struct AccountCreationDetails: View {
-    var request: WalletApprovalRequest
-    var accountCreation: BalanceAccountCreation
+struct WalletCreationDetails: View {
+    var request: ApprovalRequest
+    var accountCreation: WalletCreation
 
     var body: some View {
         VStack(alignment: .center, spacing: 10) {
@@ -49,13 +49,13 @@ extension DateComponentsFormatter {
 #if DEBUG
 struct AccountCreationDetails_Previews: PreviewProvider {
     static var previews: some View {
-        AccountCreationDetails(request: .sample, accountCreation: .sample)
+        WalletCreationDetails(request: .sample, accountCreation: .sample)
 
         let timerPublisher = Timer.TimerPublisher(interval: 1, runLoop: .current, mode: .default).autoconnect()
 
         NavigationView {
             ApprovalRequestDetails(user: .sample, request: .sample, timerPublisher: timerPublisher) {
-                AccountCreationDetails(request: .sample, accountCreation: .sample)
+                WalletCreationDetails(request: .sample, accountCreation: .sample)
             }
         }
     }

--- a/Strike/Views/ApprovalRequests/AccountCreation/WalletCreationRow.swift
+++ b/Strike/Views/ApprovalRequests/AccountCreation/WalletCreationRow.swift
@@ -8,9 +8,9 @@
 import Foundation
 import SwiftUI
 
-struct AccountCreationRow: View {
+struct WalletCreationRow: View {
     var requestType: SolanaApprovalRequestType
-    var accountCreation: BalanceAccountCreation
+    var accountCreation: WalletCreation
 
     var body: some View {
         VStack(spacing: 8) {
@@ -42,15 +42,15 @@ extension AccountType: CustomStringConvertible {
 }
 
 #if DEBUG
-struct AccountCreationRow_Previews: PreviewProvider {
+struct WalletCreationRow_Previews: PreviewProvider {
     static var previews: some View {
-        AccountCreationRow(requestType: .balanceAccountCreation(.sample), accountCreation: .sample)
+        WalletCreationRow(requestType: .walletCreation(.sample), accountCreation: .sample)
     }
 }
 
-extension BalanceAccountCreation {
+extension WalletCreation {
     static var sample: Self {
-        BalanceAccountCreation(accountSlot: 1, accountInfo: AccountInfo(name: "Rainbows", identifier: "dffdg", accountType: .BalanceAccount, address: nil, chainName: nil), approvalPolicy: ApprovalPolicy(approvalsRequired: 3, approvalTimeout: 4000000, approvers: [SlotSignerInfo(slotId: 3, value: SignerInfo(publicKey: "dsfgsfdg4534gf4", name: "John Q", email: "johnny@crypto.com", nameHashIsEmpty: false))]), whitelistEnabled: .On, dappsEnabled: .On, addressBookSlot: 4, signingData: .sample)
+        WalletCreation(accountSlot: 1, accountInfo: AccountInfo(name: "Rainbows", identifier: "dffdg", accountType: .BalanceAccount, address: nil, chainName: nil), approvalPolicy: ApprovalPolicy(approvalsRequired: 3, approvalTimeout: 4000000, approvers: [SlotSignerInfo(slotId: 3, value: SignerInfo(publicKey: "dsfgsfdg4534gf4", name: "John Q", email: "johnny@crypto.com", nameHashIsEmpty: false))]), whitelistEnabled: .On, dappsEnabled: .On, addressBookSlot: 4, signingData: .sample)
     }
 }
 

--- a/Strike/Views/ApprovalRequests/AddressBookUpdate/AddressBookUpdateDetails.swift
+++ b/Strike/Views/ApprovalRequests/AddressBookUpdate/AddressBookUpdateDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct AddressBookUpdateDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var update: AddressBookUpdate
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/ApprovalRequestDetails.swift
+++ b/Strike/Views/ApprovalRequests/ApprovalRequestDetails.swift
@@ -20,7 +20,7 @@ struct ApprovalRequestDetails<Content>: View where Content : View {
     @State private var timeRemaining: DateComponents = DateComponents()
 
     var user: StrikeApi.User
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var timerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>
     var onStatusChange: (() -> Void)?
     @ViewBuilder var content: () -> Content

--- a/Strike/Views/ApprovalRequests/ApprovalRequestItem.swift
+++ b/Strike/Views/ApprovalRequests/ApprovalRequestItem.swift
@@ -13,7 +13,7 @@ import Alamofire
 
 struct ApprovalRequestItem: View {
     var user: StrikeApi.User
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var onStatusChange: (() -> Void)?
     var timerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>
 
@@ -39,11 +39,11 @@ struct ApprovalRequestItem: View {
             } detail: {
                 SignerUpdateDetails(request: request, signersUpdate: signersUpdate)
             }
-        case .balanceAccountCreation(let accountCreation):
+        case .walletCreation(let walletCreation):
             ApprovalRequestRow(user: user, request: request, timerPublisher: timerPublisher, onStatusChange: onStatusChange) {
-                AccountCreationRow(requestType: request.requestType, accountCreation: accountCreation)
+                WalletCreationRow(requestType: request.requestType, accountCreation: walletCreation)
             } detail: {
-                AccountCreationDetails(request: request, accountCreation: accountCreation)
+                WalletCreationDetails(request: request, accountCreation: walletCreation)
             }
         case .dAppTransactionRequest(let dAppTransactionRequest):
             ApprovalRequestRow(user: user, request: request, timerPublisher: timerPublisher, onStatusChange: onStatusChange) {

--- a/Strike/Views/ApprovalRequests/ApprovalRequestRow.swift
+++ b/Strike/Views/ApprovalRequests/ApprovalRequestRow.swift
@@ -18,7 +18,7 @@ struct ApprovalRequestRow<Row, Detail>: View where Row : View, Detail: View {
     @State private var navigated = false
 
     var user: StrikeApi.User
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var timerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>
     var onStatusChange: (() -> Void)?
     @ViewBuilder var row: () -> Row
@@ -179,7 +179,7 @@ extension ApprovalRequestRow {
     }
 }
 
-extension WalletApprovalRequest {
+extension ApprovalRequest {
     var expireDate: Date? {
         approvalTimeoutInSeconds != nil ? submitDate.addingTimeInterval(TimeInterval(approvalTimeoutInSeconds!)) : nil
     }

--- a/Strike/Views/ApprovalRequests/ApprovalRequestsList.swift
+++ b/Strike/Views/ApprovalRequests/ApprovalRequestsList.swift
@@ -12,7 +12,7 @@ import Combine
 
 struct ApprovalRequestsList: View {
     var user: StrikeApi.User
-    var requests: [WalletApprovalRequest]
+    var requests: [ApprovalRequest]
     var onStatusChange: (() -> Void)?
     var onRefresh: (RefreshContext) -> Void
 

--- a/Strike/Views/ApprovalRequests/ApprovalRequestsView.swift
+++ b/Strike/Views/ApprovalRequests/ApprovalRequestsView.swift
@@ -13,7 +13,7 @@ struct ApprovalRequestsView: View {
 
     @State private var didShowApprovalRequests = false
 
-    @RemoteResult private var approvalRequests: [GracefullyDecoded<WalletApprovalRequest>]?
+    @RemoteResult private var approvalRequests: [GracefullyDecoded<ApprovalRequest>]?
 
     var user: StrikeApi.User
 
@@ -41,8 +41,8 @@ struct ApprovalRequestsView: View {
         }
     }
 
-    private var loader: MoyaLoader<[GracefullyDecoded<WalletApprovalRequest>], StrikeApi.Target> {
-        strikeApi.provider.loader(for: .walletApprovals)
+    private var loader: MoyaLoader<[GracefullyDecoded<ApprovalRequest>], StrikeApi.Target> {
+        strikeApi.provider.loader(for: .approvalRequests)
     }
 
     private func reload() {

--- a/Strike/Views/ApprovalRequests/ApprovalsNeeded.swift
+++ b/Strike/Views/ApprovalRequests/ApprovalsNeeded.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 
 struct ApprovalsNeeded: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
 
     var body: some View {
         let numApprovalsNeeded = request.numberOfDispositionsRequired - request.numberOfApprovalsReceived

--- a/Strike/Views/ApprovalRequests/BalanceAccountName/BalanceAccountNameDetails.swift
+++ b/Strike/Views/ApprovalRequests/BalanceAccountName/BalanceAccountNameDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct BalanceAccountNameDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var update: BalanceAccountNameUpdate
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/BalanceAccountPolicy/BalanceAccountPolicyDetails.swift
+++ b/Strike/Views/ApprovalRequests/BalanceAccountPolicy/BalanceAccountPolicyDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct BalanceAccountPolicyDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var update: BalanceAccountPolicyUpdate
     var user: StrikeApi.User
 

--- a/Strike/Views/ApprovalRequests/BalanceAccountSettings/BalanceAccountSettingsDetails.swift
+++ b/Strike/Views/ApprovalRequests/BalanceAccountSettings/BalanceAccountSettingsDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct BalanceAccountSettingsDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var update: BalanceAccountSettingsUpdate
     var user: StrikeApi.User
 

--- a/Strike/Views/ApprovalRequests/BalanceAccountWhitelist/BalanceAccountWhitelistDetails.swift
+++ b/Strike/Views/ApprovalRequests/BalanceAccountWhitelist/BalanceAccountWhitelistDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct BalanceAccountWhitelistDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var update: BalanceAccountAddressWhitelistUpdate
     var user: StrikeApi.User
 

--- a/Strike/Views/ApprovalRequests/Conversion/ConversionDetail.swift
+++ b/Strike/Views/ApprovalRequests/Conversion/ConversionDetail.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct ConversionDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var conversion: ConversionRequest
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/DAppTransaction/DAppTransactionDetails.swift
+++ b/Strike/Views/ApprovalRequests/DAppTransaction/DAppTransactionDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct DAppTransactionDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var transactionRequest: DAppTransactionRequest
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/SignerUpdate/SignerUpdateDetails.swift
+++ b/Strike/Views/ApprovalRequests/SignerUpdate/SignerUpdateDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct SignerUpdateDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var signersUpdate: SignersUpdate
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/UnknownRequestRow.swift
+++ b/Strike/Views/ApprovalRequests/UnknownRequestRow.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import Combine
 
 struct UnknownRequestRow: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var timerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/WalletConfigPolicy/WalletConfigPolicyDetails.swift
+++ b/Strike/Views/ApprovalRequests/WalletConfigPolicy/WalletConfigPolicyDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct WalletConfigPolicyDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var update: WalletConfigPolicyUpdate
 
     var body: some View {

--- a/Strike/Views/ApprovalRequests/Withdrawal/WithdrawalDetails.swift
+++ b/Strike/Views/ApprovalRequests/Withdrawal/WithdrawalDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct WithdrawalDetails: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var withdrawal: WithdrawalRequest
 
     var body: some View {
@@ -26,7 +26,7 @@ struct WithdrawalDetails: View {
     }
 }
 
-extension WalletApprovalRequest {
+extension ApprovalRequest {
     var numberOfApprovalsNeeded: Int {
         numberOfDispositionsRequired - numberOfApprovalsReceived
     }

--- a/Strike/Views/ApprovalRequests/WrapConverstion/WrapConversionDetail.swift
+++ b/Strike/Views/ApprovalRequests/WrapConverstion/WrapConversionDetail.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct WrapConversionDetail: View {
-    var request: WalletApprovalRequest
+    var request: ApprovalRequest
     var conversion: WrapConversionRequest
 
     var body: some View {

--- a/StrikeTests/StrikeTestHelper.swift
+++ b/StrikeTests/StrikeTestHelper.swift
@@ -67,20 +67,20 @@ extension StrikeTests {
         )
     }
 
-    func getSignersUpdateWalletRequest(nonceAccountAddresses: [String]) ->  WalletApprovalRequest {
-        return getWalletApprovalRequest(getSignersUpdateRequest(nonceAccountAddresses: nonceAccountAddresses))
+    func getSignersUpdateApprovalRequest(nonceAccountAddresses: [String]) ->  ApprovalRequest {
+        return getApprovalRequest(getSignersUpdateRequest(nonceAccountAddresses: nonceAccountAddresses))
     }
         
-    func getBalanceAccountCreationRequest(nonceAccountAddresses: [String]) -> SolanaApprovalRequestType {
-        return .balanceAccountCreation(
-            BalanceAccountCreation(
+    func getSolanaWalletCreationRequest(nonceAccountAddresses: [String]) -> SolanaApprovalRequestType {
+        return .walletCreation(
+            WalletCreation(
                 accountSlot: 0,
                 accountInfo: AccountInfo(
                     name: "Account 1",
                     identifier: "c6055be1-a895-45a6-b0f3-fce261760b89",
                     accountType: AccountType.BalanceAccount,
                     address: nil,
-                    chainName: nil
+                    chainName: "Solana"
                 ),
                 approvalPolicy: ApprovalPolicy(
                     approvalsRequired: 1,
@@ -111,6 +111,63 @@ extension StrikeTests {
         )
     }
     
+    func getBitcoinWalletCreationRequest() -> SolanaApprovalRequestType {
+        return .walletCreation(
+            WalletCreation(
+                accountSlot: 0,
+                accountInfo: AccountInfo(
+                    name: "Account 1",
+                    identifier: "c6055be1-a895-45a6-b0f3-fce261760b89",
+                    accountType: AccountType.BalanceAccount,
+                    address: nil,
+                    chainName: "Bitcoin"
+                ),
+                approvalPolicy: ApprovalPolicy(
+                    approvalsRequired: 1,
+                    approvalTimeout: 3600000,
+                    approvers: [SlotSignerInfo(slotId: 0, value: SignerInfo(
+                        publicKey: "3wKxhgiogoCaA2uxPYeH7cy3cG4hxRPogrPmDPLS54iZ",
+                        name: "User 1",
+                        email: "authorized1@org1",
+                        nameHashIsEmpty: false
+                    ))]
+                ),
+                whitelistEnabled: BooleanSetting.Off,
+                dappsEnabled: BooleanSetting.Off,
+                addressBookSlot: 1,
+                signingData: nil
+            )
+        )
+    }
+    
+    func getEthereumWalletCreationRequest() -> SolanaApprovalRequestType {
+        return .walletCreation(
+            WalletCreation(
+                accountSlot: 0,
+                accountInfo: AccountInfo(
+                    name: "Account 1",
+                    identifier: "c6055be1-a895-45a6-b0f3-fce261760b89",
+                    accountType: AccountType.BalanceAccount,
+                    address: nil,
+                    chainName: "Ethereum"
+                ),
+                approvalPolicy: ApprovalPolicy(
+                    approvalsRequired: 1,
+                    approvalTimeout: 3600000,
+                    approvers: [SlotSignerInfo(slotId: 0, value: SignerInfo(
+                        publicKey: "3wKxhgiogoCaA2uxPYeH7cy3cG4hxRPogrPmDPLS54iZ",
+                        name: "User 1",
+                        email: "authorized1@org1",
+                        nameHashIsEmpty: false
+                    ))]
+                ),
+                whitelistEnabled: BooleanSetting.Off,
+                dappsEnabled: BooleanSetting.Off,
+                addressBookSlot: 1,
+                signingData: nil
+            )
+        )
+    }
  
     func getSolWithdrawalRequest(nonceAccountAddresses: [String]) -> SolanaApprovalRequestType {
         return .withdrawalRequest(
@@ -615,10 +672,9 @@ extension StrikeTests {
     }
     
     
-    func getWalletApprovalRequest(_ requestType: SolanaApprovalRequestType) -> WalletApprovalRequest {
-        return WalletApprovalRequest(
+    func getApprovalRequest(_ requestType: SolanaApprovalRequestType) -> ApprovalRequest {
+        return ApprovalRequest(
             id: "1",
-            walletType: WalletType.Solana,
             submitterName: "",
             submitterEmail: "",
             submitDate: Date(),
@@ -631,10 +687,9 @@ extension StrikeTests {
         )
     }
 
-    func getWalletInitiationRequest(_ requestType: SolanaApprovalRequestType, initiation: MultisigOpInitiation) -> WalletApprovalRequest {
-        return WalletApprovalRequest(
+    func getWalletInitiationRequest(_ requestType: SolanaApprovalRequestType, initiation: MultisigOpInitiation) -> ApprovalRequest {
+        return ApprovalRequest(
             id: "1",
-            walletType: WalletType.Solana,
             submitterName: "",
             submitterEmail: "",
             submitDate: Date(),

--- a/StrikeTests/StrikeTests.swift
+++ b/StrikeTests/StrikeTests.swift
@@ -12,7 +12,7 @@ import CryptoKit
 class StrikeTests: XCTestCase {
     
     func testSignersUpdateSerializedOp() throws {
-        let request: WalletApprovalRequest = getSignersUpdateWalletRequest(nonceAccountAddresses: ["6XQy8HrrMmsfmajFpWo5tWhDUiESg8obA4NGWJwjNgpR"])
+        let request: ApprovalRequest = getSignersUpdateApprovalRequest(nonceAccountAddresses: ["6XQy8HrrMmsfmajFpWo5tWhDUiESg8obA4NGWJwjNgpR"])
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -27,7 +27,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testSignersUpdateApprovalDisposition() throws {
-        let request: WalletApprovalRequest = getWalletApprovalRequest(getSignersUpdateRequestForApproval(nonceAccountAddresses: ["Deuspj2g5crN81b6GocKANAhB3Y5D6XseXjiT1bery7Z"]))
+        let request: ApprovalRequest = getApprovalRequest(getSignersUpdateRequestForApproval(nonceAccountAddresses: ["Deuspj2g5crN81b6GocKANAhB3Y5D6XseXjiT1bery7Z"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -65,8 +65,8 @@ class StrikeTests: XCTestCase {
         )
     }
 
-    func testBalanceAccountCreationApprovalDisposition() throws {
-        let request = getWalletApprovalRequest(getBalanceAccountCreationRequest(nonceAccountAddresses: ["Hy4Ztych4X12wWieCaFbSEbwZRxmjRTMgbm7RDybYTpD"]))
+    func testSolanaWalletCreationApprovalDisposition() throws {
+        let request = getApprovalRequest(getSolanaWalletCreationRequest(nonceAccountAddresses: ["Hy4Ztych4X12wWieCaFbSEbwZRxmjRTMgbm7RDybYTpD"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -80,12 +80,48 @@ class StrikeTests: XCTestCase {
         )
     }
     
-    func testBalanceAccountCreationInitiationRequest() throws {
+    func testBitcoinWalletCreationApprovalDisposition() throws {
+        let request = getApprovalRequest(getBitcoinWalletCreationRequest())
+        let approvalRequest = StrikeApi.ApprovalDispositionRequest(
+            disposition: .Approve,
+            requestID: request.id,
+            requestType: request.requestType,
+            nonces: [],
+            email: "dont care"
+        )
+        
+        let signableData = try approvalRequest.signableData(approverPublicKey: "7AH35qStXtrUgRkmqDmhjufNHjF74R1A9cCKT3C3HaAR")
+        
+        XCTAssertEqual(
+            try JSONDecoder().decode(SolanaApprovalRequestType.self, from: signableData),
+            approvalRequest.requestType
+        )
+    }
+    
+    func testEthereumWalletCreationApprovalDisposition() throws {
+        let request = getApprovalRequest(getEthereumWalletCreationRequest())
+        let approvalRequest = StrikeApi.ApprovalDispositionRequest(
+            disposition: .Approve,
+            requestID: request.id,
+            requestType: request.requestType,
+            nonces: [],
+            email: "dont care"
+        )
+        
+        let signableData = try approvalRequest.signableData(approverPublicKey: "7AH35qStXtrUgRkmqDmhjufNHjF74R1A9cCKT3C3HaAR")
+        
+        XCTAssertEqual(
+            try JSONDecoder().decode(SolanaApprovalRequestType.self, from: signableData),
+            approvalRequest.requestType
+        )
+    }
+    
+    func testWalletCreationInitiationRequest() throws {
         let initiation = MultisigOpInitiation(
             opAccountCreationInfo: getOpAccountCreationInfo(),
             initiatorIsApprover: true
         )
-        let requestType: SolanaApprovalRequestType = getBalanceAccountCreationRequest(nonceAccountAddresses: ["CL8fZq5BzjCBXmixSMKqBsFoCLSFxqN6GvheDQ68HP44"])
+        let requestType: SolanaApprovalRequestType = getSolanaWalletCreationRequest(nonceAccountAddresses: ["CL8fZq5BzjCBXmixSMKqBsFoCLSFxqN6GvheDQ68HP44"])
         let request = getWalletInitiationRequest(requestType, initiation: initiation)
         let pk = try Curve25519.Signing.PrivateKey.init(rawRepresentation: "2d7db52f8ff35aec03cd7be8d26c45d798774a4d5dfa9a9c559778752fb87d11".data(using: .hexadecimal)!)
         let initiationRequest = StrikeApi.InitiationRequest(
@@ -105,7 +141,7 @@ class StrikeTests: XCTestCase {
     }
     
     func testSolWithdrawalRequestApprovalDisposition() throws {
-        let request = getWalletApprovalRequest(getSolWithdrawalRequest(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
+        let request = getApprovalRequest(getSolWithdrawalRequest(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -145,7 +181,7 @@ class StrikeTests: XCTestCase {
 
 
     func testSplWithdrawalRequestApprovalDisposition() throws {
-        let request = getWalletApprovalRequest(getSplWithdrawalRequest(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
+        let request = getApprovalRequest(getSplWithdrawalRequest(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -184,7 +220,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testUSDCconversionRequestApprovalDisposition() throws {
-        let request = getWalletApprovalRequest(getConversionRequest(nonceAccountAddresses: ["6UcFAr9rqGfFEtLxnYdW6QjeRor3aej5akLpYpXUkPWX"]))
+        let request = getApprovalRequest(getConversionRequest(nonceAccountAddresses: ["6UcFAr9rqGfFEtLxnYdW6QjeRor3aej5akLpYpXUkPWX"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -321,7 +357,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testDAppTransactionRequestApprovalDisposition() throws {
-        let request = getWalletApprovalRequest(getDAppTransactionRequest(nonceAccountAddresses: ["7mKUZ5BjRu1bwbhFWNfhntaXnT1L1H7XNDfCi3Bc9zYf"]))
+        let request = getApprovalRequest(getDAppTransactionRequest(nonceAccountAddresses: ["7mKUZ5BjRu1bwbhFWNfhntaXnT1L1H7XNDfCi3Bc9zYf"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -336,7 +372,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testAddDAppBookEntryApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getAddDAppBookEntry(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
+        let request = getApprovalRequest(getAddDAppBookEntry(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -375,7 +411,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testRemoveDAppBookEntryApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getRemoveDAppBookEntry(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
+        let request = getApprovalRequest(getRemoveDAppBookEntry(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -438,7 +474,7 @@ class StrikeTests: XCTestCase {
     }
     
     func testAddAddressBookEntryApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getAddAddressBookEntry(nonceAccountAddresses: ["Aj8MqPBaM8fSbgJiUtq2PXESGTSQPsgHqJ13JyzQZCRZ"]))
+        let request = getApprovalRequest(getAddAddressBookEntry(nonceAccountAddresses: ["Aj8MqPBaM8fSbgJiUtq2PXESGTSQPsgHqJ13JyzQZCRZ"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -454,7 +490,7 @@ class StrikeTests: XCTestCase {
     
 
     func testWalletConfigPolicyUpdateApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getWalletConfigPolicyUpdate(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
+        let request = getApprovalRequest(getWalletConfigPolicyUpdate(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -494,7 +530,7 @@ class StrikeTests: XCTestCase {
     
 
     func testBalanceAccountSettingsUpdateApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getBalanceAccountSettingsUpdate(nonceAccountAddresses: ["CpBzxGEDYnzi9jfGteSR6sCnmtT9XwirXQaCtSvmWnka"]))
+        let request = getApprovalRequest(getBalanceAccountSettingsUpdate(nonceAccountAddresses: ["CpBzxGEDYnzi9jfGteSR6sCnmtT9XwirXQaCtSvmWnka"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -533,7 +569,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testBalanceAccountPolicyUpdateApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getBalanceAccountPolicyUpdate(nonceAccountAddresses: ["BzZpoiceSXQTtrrZUMU67s6pCJzqCDJAVvgJCRw64fJV"]))
+        let request = getApprovalRequest(getBalanceAccountPolicyUpdate(nonceAccountAddresses: ["BzZpoiceSXQTtrrZUMU67s6pCJzqCDJAVvgJCRw64fJV"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -572,7 +608,7 @@ class StrikeTests: XCTestCase {
     }
     
     func testBalanceAccountAddressWhitelistUpdateApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getBalanceAccountAddressWhitelistUpdate(nonceAccountAddresses: ["481dDMZGAiATXnLkBw1mEMdsJSwWWg3F2zHEsciaXZ98"]))
+        let request = getApprovalRequest(getBalanceAccountAddressWhitelistUpdate(nonceAccountAddresses: ["481dDMZGAiATXnLkBw1mEMdsJSwWWg3F2zHEsciaXZ98"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -611,7 +647,7 @@ class StrikeTests: XCTestCase {
     }
 
     func testBalanceAccountNameUpdateApprovalRequest() throws {
-        let request = getWalletApprovalRequest(getBalanceAccountNameUpdate(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
+        let request = getApprovalRequest(getBalanceAccountNameUpdate(nonceAccountAddresses: ["AaFj4THN8CJmDPyJjPuDpsfC5FZys2Wmczust5UfmqeN"]))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -653,7 +689,7 @@ class StrikeTests: XCTestCase {
         let jwtToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImF1ZCI6IlNvbHIifQ.SWCJDd6B_m7xr_puQH-wgbxvXyJYXH9lTpldOU0eQKc"
         let email = "sample@email.co"
         let name = "Sample User Name"
-        let request = getWalletApprovalRequest(getLoginApproval(jwtToken, email: email, name: name))
+        let request = getApprovalRequest(getLoginApproval(jwtToken, email: email, name: name))
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -668,9 +704,9 @@ class StrikeTests: XCTestCase {
     }
     
     func testAcceptVaultInvitation() throws {
-        let approvalData = "{\"id\": \"422e3504-4eea-493a-a0dd-64a001115540\", \"walletType\": \"Solana\", \"submitDate\": \"2022-06-21T14:20:38.145+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org1\", \"numberOfDispositionsRequired\": 1, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"programVersion\": null, \"details\": {\"type\": \"AcceptVaultInvitation\", \"vaultGuid\": \"58e03f93-b9bc-4f22-b485-8e7a0abd8440\", \"vaultName\": \"Test Organization 1\"}, \"vaultName\": \"Test Organization 1\"}\n"
+        let approvalData = "{\"id\": \"422e3504-4eea-493a-a0dd-64a001115540\", \"submitDate\": \"2022-06-21T14:20:38.145+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org1\", \"numberOfDispositionsRequired\": 1, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"details\": {\"type\": \"AcceptVaultInvitation\", \"vaultGuid\": \"58e03f93-b9bc-4f22-b485-8e7a0abd8440\", \"vaultName\": \"Test Organization 1\"}, \"vaultName\": \"Test Organization 1\"}\n"
 
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
+        let request: ApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
         let approvalDispositionRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -691,9 +727,9 @@ class StrikeTests: XCTestCase {
     }
     
     func testPasswordReset() throws {
-        let approvalData = "{\"id\": \"422e3504-4eea-493a-a0dd-64a001115540\", \"walletType\": \"Solana\", \"submitDate\": \"2022-06-21T14:20:38.145+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org1\", \"numberOfDispositionsRequired\": 1, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"programVersion\": null, \"details\": {\"type\": \"PasswordReset\"}}\n"
+        let approvalData = "{\"id\": \"422e3504-4eea-493a-a0dd-64a001115540\", \"submitDate\": \"2022-06-21T14:20:38.145+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org1\", \"numberOfDispositionsRequired\": 1, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"details\": {\"type\": \"PasswordReset\"}}\n"
 
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
+        let request: ApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
         let approvalDispositionRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -740,10 +776,10 @@ class StrikeTests: XCTestCase {
     }
     
     func testSignDataForPlainTextApprovalRequest() throws {
-        let approvalData = "{\"id\": \"6a196209-b207-47a8-aff0-b609324c9e0e\", \"walletType\": \"Solana\", \"submitDate\": \"2022-09-10T10:35:20.161+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org4\", \"approvalTimeoutInSeconds\": 18000, \"numberOfDispositionsRequired\": 2, \"numberOfApprovalsReceived\": 1, \"numberOfDeniesReceived\": 0, \"programVersion\": 1, \"details\": {\"type\": \"SignData\", \"base64Data\": \"U29tZSCxbmFyeSDadGE=\", \"signingData\": {\"feePayer\": \"87VXbkJsqdDvXYfDBtS4kW4TcFor7ogofZXbXjT7t7AU\", \"walletProgramId\": \"Hk3CaEtWizNe4tJ8heB1MEsFXuc82PaEgKY3V1eRnFHt\", \"multisigOpAccountAddress\": \"B9k6TF3TqxxErAjm9xbEM1wo6pXL7awUBVwz9GHSvK4d\", \"walletAddress\": \"5u9Q3gR5ZEHG3FYben6b4XnRUgsdV1CGzUp1CGo2xpcp\", \"nonceAccountAddresses\": [\"GG9poSiQMRyZRVR8vSATYZBFcRncamRDyMiumDXDkgHM\"], \"nonceAccountAddressesSlot\": 481, \"initiator\": \"5SrmRzk1CGbHLt8UrNdBXVLtSeje3zW9y9CpfnrS78w\", \"strikeFeeAmount\": 0, \"feeAccountGuidHash\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\", \"walletGuidHash\": \"RATnHZIZKJRvD0BHwo2on7xqdHNtVMS3U9dqD3o3fLc=\"}}, \"vaultName\": \"Test Organization 4\"}\n"
+        let approvalData = "{\"id\": \"6a196209-b207-47a8-aff0-b609324c9e0e\", \"submitDate\": \"2022-09-10T10:35:20.161+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org4\", \"approvalTimeoutInSeconds\": 18000, \"numberOfDispositionsRequired\": 2, \"numberOfApprovalsReceived\": 1, \"numberOfDeniesReceived\": 0, \"details\": {\"type\": \"SignData\", \"base64Data\": \"U29tZSCxbmFyeSDadGE=\", \"signingData\": {\"feePayer\": \"87VXbkJsqdDvXYfDBtS4kW4TcFor7ogofZXbXjT7t7AU\", \"walletProgramId\": \"Hk3CaEtWizNe4tJ8heB1MEsFXuc82PaEgKY3V1eRnFHt\", \"multisigOpAccountAddress\": \"B9k6TF3TqxxErAjm9xbEM1wo6pXL7awUBVwz9GHSvK4d\", \"walletAddress\": \"5u9Q3gR5ZEHG3FYben6b4XnRUgsdV1CGzUp1CGo2xpcp\", \"nonceAccountAddresses\": [\"GG9poSiQMRyZRVR8vSATYZBFcRncamRDyMiumDXDkgHM\"], \"nonceAccountAddressesSlot\": 481, \"initiator\": \"5SrmRzk1CGbHLt8UrNdBXVLtSeje3zW9y9CpfnrS78w\", \"strikeFeeAmount\": 0, \"feeAccountGuidHash\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\", \"walletGuidHash\": \"RATnHZIZKJRvD0BHwo2on7xqdHNtVMS3U9dqD3o3fLc=\"}}, \"vaultName\": \"Test Organization 4\"}\n"
 
 
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
+        let request: ApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
             requestID: request.id,
@@ -758,9 +794,9 @@ class StrikeTests: XCTestCase {
     }
 
     func testSignDataForPlainTextInitiationRequest() throws {
-        let approvalData = "{\"id\": \"6a196209-b207-47a8-aff0-b609324c9e0e\", \"walletType\": \"Solana\", \"submitDate\": \"2022-09-10T10:35:20.161+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org4\", \"approvalTimeoutInSeconds\": null, \"numberOfDispositionsRequired\": 2, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"programVersion\": 1, \"details\": {\"type\": \"MultisigOpInitiation\", \"details\": {\"type\": \"SignData\", \"base64Data\": \"U29tZSCxbmFyeSDadGE=\", \"signingData\": {\"feePayer\": \"87VXbkJsqdDvXYfDBtS4kW4TcFor7ogofZXbXjT7t7AU\", \"walletProgramId\": \"Hk3CaEtWizNe4tJ8heB1MEsFXuc82PaEgKY3V1eRnFHt\", \"multisigOpAccountAddress\": \"11111111111111111111111111111111\", \"walletAddress\": \"5u9Q3gR5ZEHG3FYben6b4XnRUgsdV1CGzUp1CGo2xpcp\", \"nonceAccountAddresses\": [\"GqH8ELz24NLWArdzGFa8Y29eLHgfvCpJhnAQjAvycznf\"], \"nonceAccountAddressesSlot\": 479, \"initiator\": \"5SrmRzk1CGbHLt8UrNdBXVLtSeje3zW9y9CpfnrS78w\", \"strikeFeeAmount\": 0, \"feeAccountGuidHash\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\", \"walletGuidHash\": \"RATnHZIZKJRvD0BHwo2on7xqdHNtVMS3U9dqD3o3fLc=\"}}, \"opAccountCreationInfo\": {\"accountSize\": 3649, \"minBalanceForRentExemption\": 26287920}, \"initiatorIsApprover\": true}, \"vaultName\": \"Test Organization 4\"}\n"
+        let approvalData = "{\"id\": \"6a196209-b207-47a8-aff0-b609324c9e0e\", \"submitDate\": \"2022-09-10T10:35:20.161+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org4\", \"approvalTimeoutInSeconds\": null, \"numberOfDispositionsRequired\": 2, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"details\": {\"type\": \"MultisigOpInitiation\", \"details\": {\"type\": \"SignData\", \"base64Data\": \"U29tZSCxbmFyeSDadGE=\", \"signingData\": {\"feePayer\": \"87VXbkJsqdDvXYfDBtS4kW4TcFor7ogofZXbXjT7t7AU\", \"walletProgramId\": \"Hk3CaEtWizNe4tJ8heB1MEsFXuc82PaEgKY3V1eRnFHt\", \"multisigOpAccountAddress\": \"11111111111111111111111111111111\", \"walletAddress\": \"5u9Q3gR5ZEHG3FYben6b4XnRUgsdV1CGzUp1CGo2xpcp\", \"nonceAccountAddresses\": [\"GqH8ELz24NLWArdzGFa8Y29eLHgfvCpJhnAQjAvycznf\"], \"nonceAccountAddressesSlot\": 479, \"initiator\": \"5SrmRzk1CGbHLt8UrNdBXVLtSeje3zW9y9CpfnrS78w\", \"strikeFeeAmount\": 0, \"feeAccountGuidHash\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\", \"walletGuidHash\": \"RATnHZIZKJRvD0BHwo2on7xqdHNtVMS3U9dqD3o3fLc=\"}}, \"opAccountCreationInfo\": {\"accountSize\": 3649, \"minBalanceForRentExemption\": 26287920}, \"initiatorIsApprover\": true}, \"vaultName\": \"Test Organization 4\"}\n"
 
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
+        let request: ApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
         let pk = try Curve25519.Signing.PrivateKey.init(rawRepresentation: "afbdbb77f072edf581050da4f60bdaf543fe4bed493e011bb4f411345940976e".data(using: .hexadecimal)!)
         let initiationRequest = StrikeApi.InitiationRequest(
             disposition: .Approve,
@@ -778,50 +814,10 @@ class StrikeTests: XCTestCase {
         )
     }
     
-    func testSignDataForBalanceAccountCreationApprovalRequest() throws {
-        let approvalData = "{\"id\": \"33d18d6c-7fb7-4325-b0af-4b6da8a05690\", \"walletType\": \"Solana\", \"submitDate\": \"2022-09-09T20:49:47.249+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org5\", \"approvalTimeoutInSeconds\": 18000, \"numberOfDispositionsRequired\": 2, \"numberOfApprovalsReceived\": 1, \"numberOfDeniesReceived\": 0, \"programVersion\": 1, \"details\": {\"type\": \"SignData\", \"base64Data\": \"eyJfdHlwZSI6IkNyZWF0ZUJhbGFuY2VBY2NvdW50IiwicHJvdmlkZXJJZCI6ImJpdGNvaW4iLCJkYXRhIjp7InR5cGUiOiJCYWxhbmNlQWNjb3VudENyZWF0aW9uIiwiYWNjb3VudFNsb3QiOjAsImFjY291bnRJbmZvIjp7ImlkZW50aWZpZXIiOiI3ZDE1MTQ1Ni0yOGNiLTRmZjUtYTZiOC1iOTg4ODVlODdkMTkiLCJuYW1lIjoiQml0Y29pbiBBY2NvdW50IDEiLCJhY2NvdW50VHlwZSI6IkJhbGFuY2VBY2NvdW50IiwiYWRkcmVzcyI6Im14RW1MVWRYYVEza2huRVhyR1ZmQ1dRQnVTRG03Q2VYWEQifSwiYXBwcm92YWxQb2xpY3kiOnsiYXBwcm92YWxzUmVxdWlyZWQiOjEsImFwcHJvdmFsVGltZW91dCI6MzYwMDAwMCwiYXBwcm92ZXJzIjpbeyJzbG90SWQiOjAsInZhbHVlIjp7InB1YmxpY0tleSI6InlYYkdINjJnWUI3dzR6aUMxZXlyS29YM2I4UzMyWkttcXFoRWFDUzF3WFBEdkhvTXdpRmVmZ3Z5TXZmWlFUTXZIQ1pyV1NocDVGWHVMZWFpTUxNUGtSOSIsIm5hbWUiOiJVc2VyIDEiLCJlbWFpbCI6ImF1dGhvcml6ZWQxQG9yZzUiLCJuYW1lSGFzaElzRW1wdHkiOnRydWV9fV19LCJ3aGl0ZWxpc3RFbmFibGVkIjoiT2ZmIiwiZGFwcHNFbmFibGVkIjoiT2ZmIiwiYWRkcmVzc0Jvb2tTbG90IjowLCJzdGFraW5nVmFsaWRhdG9yIjpudWxsLCJzaWduaW5nRGF0YSI6eyJmZWVQYXllciI6IiIsIndhbGxldFByb2dyYW1JZCI6IiIsIm11bHRpc2lnT3BBY2NvdW50QWRkcmVzcyI6IiIsIndhbGxldEFkZHJlc3MiOiIiLCJub25jZUFjY291bnRBZGRyZXNzZXMiOltdLCJub25jZUFjY291bnRBZGRyZXNzZXNTbG90IjowLCJpbml0aWF0b3IiOiIiLCJzdHJpa2VGZWVBbW91bnQiOjAsImZlZUFjY291bnRHdWlkSGFzaCI6IiIsIndhbGxldEd1aWRIYXNoIjoiIn19fQ==\", \"signingData\": {\"feePayer\": \"87VXbkJsqdDvXYfDBtS4kW4TcFor7ogofZXbXjT7t7AU\", \"walletProgramId\": \"GYdjan963vVRh8sHAQeXy8U6aBmsSHuUTYio6R4br7K1\", \"multisigOpAccountAddress\": \"zoUp5YxMz1jm7T2iQ3FbjUCFV2yNQpNrUW2R7UNXZ7E\", \"walletAddress\": \"74KQTHwW3f6fvqrkqE7GeoRJQyGinV6xMdJ6BpPET8rG\", \"nonceAccountAddresses\": [\"EhvNkf9T3ZHnLmtsgLRJ3TmGWe6oWvRQejSTqzG6xaou\"], \"nonceAccountAddressesSlot\": 16224, \"initiator\": \"7nTeukQZH8FSg59VbsCeQqyAojpLjcRvueXLRpxDr3fn\", \"strikeFeeAmount\": 0, \"feeAccountGuidHash\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\", \"walletGuidHash\": \"OTDldXFSr0Rn49uJ/MIDYqmE1DBHT7S8bIrLSHNo9Yw=\"}}, \"vaultName\": \"Test Organization 5\"}\n"
-
-
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
-        let approvalRequest = StrikeApi.ApprovalDispositionRequest(
-            disposition: .Approve,
-            requestID: request.id,
-            requestType: request.requestType,
-            nonces: [StrikeApi.Nonce("9dNtUVv25bMpyrFyRgrgdmygymYxeCiw8geHfKLVYnyu")],
-            email: "dont care"
-        )
-        XCTAssertEqual(
-            try approvalRequest.signableData(approverPublicKey: "7xQTcWf8hWnYb2DfNHX43qGSmME8TAcvPY6DJ9KPUnTK").toHexString(),
-            "0201040869ab8cb05413af9614f898a1f1fdfbc07e7ad5eb2eb1d0f1c49f448bd179c7156757974e9d4a7a1f6367333182c168c8abaa4616428d182e6e7d77b675458aa2cba3838600fb16cdfe56197da6ebc0e943ed59c03ea18539c79049d5e802a0cc0ecea9219bc5d14e3119b89bdece9afaf3a91e6db985961c16181349c49d094906a7d517192c568ee08a845f73d29788cf035c3145b21ab344d8062ea940000006a7d51718c774c928566398691d5eb68b5eb8a39b4b6d5c73555b21000000000000000000000000000000000000000000000000000000000000000000000000e6f9d82d908d2e9a64f43557fbaefd85806a4b1fcb08454bcb5bab5f2ab8d014802f271d98da48f43a3cbdbfb5623a006de53b3f24771acba31f2f265b789530020603020400040400000007030301052209016e60d6be52226fc9f59faff76a8258b86c5b34eefaaf1fb21b5d1e918d515cd6"
-        )
-    }
-
-    func testSignDataForBalanceAccountCreationInitiationRequest() throws {
-        let approvalData = "{\"id\": \"00c06a34-75b5-48b1-bbb4-fddc8addb8ee\", \"walletType\": \"Solana\", \"submitDate\": \"2022-09-09T20:06:11.425+00:00\", \"submitterName\": \"User 1\", \"submitterEmail\": \"authorized1@org5\", \"approvalTimeoutInSeconds\": null, \"numberOfDispositionsRequired\": 2, \"numberOfApprovalsReceived\": 0, \"numberOfDeniesReceived\": 0, \"programVersion\": 1, \"details\": {\"type\": \"MultisigOpInitiation\", \"details\": {\"type\": \"SignData\", \"base64Data\": \"eyJfdHlwZSI6IkNyZWF0ZUJhbGFuY2VBY2NvdW50IiwicHJvdmlkZXJJZCI6ImJpdGNvaW4iLCJkYXRhIjp7InR5cGUiOiJCYWxhbmNlQWNjb3VudENyZWF0aW9uIiwiYWNjb3VudFNsb3QiOjAsImFjY291bnRJbmZvIjp7ImlkZW50aWZpZXIiOiI1NTczNmMyMy04ZjE4LTRmM2UtYjM2MC05ZmI5MTQ5MjNiOTIiLCJuYW1lIjoiQml0Y29pbiBBY2NvdW50IDEiLCJhY2NvdW50VHlwZSI6IkJhbGFuY2VBY2NvdW50IiwiYWRkcmVzcyI6Im16U2JqOXJpUWtBNUJESzk0SGo5WUJNRnZlQ0pZVHhkdWEifSwiYXBwcm92YWxQb2xpY3kiOnsiYXBwcm92YWxzUmVxdWlyZWQiOjEsImFwcHJvdmFsVGltZW91dCI6MzYwMDAwMCwiYXBwcm92ZXJzIjpbeyJzbG90SWQiOjAsInZhbHVlIjp7InB1YmxpY0tleSI6IjIxQWNqWWRHbmZuTHZuc1BYdkF5TEZrbmVNa052MzljTGdNTU5kU0wyWTg5bVlwYlN5dFoyeUZiV0hFWjZrTGc2OUZKMkZDVDhOYVNVdlkzV2pTMTJCV28iLCJuYW1lIjoiVXNlciAxIiwiZW1haWwiOiJhdXRob3JpemVkMUBvcmc1IiwibmFtZUhhc2hJc0VtcHR5Ijp0cnVlfX1dfSwid2hpdGVsaXN0RW5hYmxlZCI6Ik9mZiIsImRhcHBzRW5hYmxlZCI6Ik9mZiIsImFkZHJlc3NCb29rU2xvdCI6MCwic3Rha2luZ1ZhbGlkYXRvciI6bnVsbCwic2lnbmluZ0RhdGEiOnsiZmVlUGF5ZXIiOiIiLCJ3YWxsZXRQcm9ncmFtSWQiOiIiLCJtdWx0aXNpZ09wQWNjb3VudEFkZHJlc3MiOiIiLCJ3YWxsZXRBZGRyZXNzIjoiIiwibm9uY2VBY2NvdW50QWRkcmVzc2VzIjpbXSwibm9uY2VBY2NvdW50QWRkcmVzc2VzU2xvdCI6MCwiaW5pdGlhdG9yIjoiIiwic3RyaWtlRmVlQW1vdW50IjowLCJmZWVBY2NvdW50R3VpZEhhc2giOiIiLCJ3YWxsZXRHdWlkSGFzaCI6IiJ9fX0=\", \"signingData\": {\"feePayer\": \"87VXbkJsqdDvXYfDBtS4kW4TcFor7ogofZXbXjT7t7AU\", \"walletProgramId\": \"4Kra2q9aGe9n5YAarPWH3BvZSXVBLAZTCQhuPh9VQun1\", \"multisigOpAccountAddress\": \"11111111111111111111111111111111\", \"walletAddress\": \"37jZd3fa6hQ98ufPFA6N7WQvUm6DtsBjnEakGY5pqrB9\", \"nonceAccountAddresses\": [\"Gntfv3uZaqEJTrm2BWy87ZgTPEyPwyEVQGVhdhGvLA5j\"], \"nonceAccountAddressesSlot\": 10462, \"initiator\": \"4Gyit71SY3zUUmDMvAT3Lqbex8wBhWJRx8xpEXd5qq66\", \"strikeFeeAmount\": 0, \"feeAccountGuidHash\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\", \"walletGuidHash\": \"9KVyRePx9RQkHs8orY2k87NzyoSiLkPsjpVxCIgUlLA=\"}}, \"opAccountCreationInfo\": {\"accountSize\": 3649, \"minBalanceForRentExemption\": 26287920}, \"initiatorIsApprover\": true}, \"vaultName\": \"Test Organization 5\"}\n"
-
-
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
-        let pk = try Curve25519.Signing.PrivateKey.init(rawRepresentation: "5647f96596cf1d7e5b3e8f79401840dee7125aded4b185e66963f0d56c1466bb".data(using: .hexadecimal)!)
-        let initiationRequest = StrikeApi.InitiationRequest(
-            disposition: .Approve,
-            requestID: request.id,
-            initiation: getOpAccountCreationInfo(request)!,
-            requestType: request.requestType,
-            nonces: [StrikeApi.Nonce("6ZY5GcyceDoL9ezZcT2znhnCSacePMtZYUhcXETyrRcb")],
-            email: "dont care",
-            opAccountPrivateKey: pk
-        )
-
-        XCTAssertEqual(
-            try initiationRequest.signableData(approverPublicKey: "4Gyit71SY3zUUmDMvAT3Lqbex8wBhWJRx8xpEXd5qq66").toHexString(),
-            "0301040969ab8cb05413af9614f898a1f1fdfbc07e7ad5eb2eb1d0f1c49f448bd179c715eaed3fd176bbffdb0f461ecd630cda4222a93ebc95765d0355dc0b30379d438c30aae8a6182fd1294d717eacf294e2ed515bfe980cba907006a100928bddfb27eaa0dd6522a309e59454de9c2f37e8cef9bd8d10683b6f035faa9f9504fa88fe1f70fbf53c47a529b7275ea23a1d4c811cd0210f748bd1b70fcf05b6f53baa6006a7d517192c568ee08a845f73d29788cf035c3145b21ab344d8062ea940000006a7d51718c774c928566398691d5eb68b5eb8a39b4b6d5c73555b2100000000000000000000000000000000000000000000000000000000000000000000000031679052f04f2d670da777f48a043ebadc013c519b3a60fe9be19546844002da52a027d3066f2028195e3a2a3b00fb521729f6bbd885c3e941600ef9af8b76180307030305000404000000070200013400000000301f910100000000410e00000000000031679052f04f2d670da777f48a043ebadc013c519b3a60fe9be19546844002da080501040206004c2300000000000000000000000000000000000000000000000000000000000000000000000000000000002000e20ac1082fd5ef74246e6fe2cde37d41a449aee5ee9ba84936db99b37aec714e"
-        )
-    }
-    
     func testBitcoinWithdrawalApproval() throws {
-        let approvalData = "{\"id\":\"77475988-fd42-41c0-8ef6-cba19c1b1251\",\"walletType\":\"Solana\",\"submitDate\":\"2022-09-28T22:58:12.035+00:00\",\"submitterName\":\"User 1\",\"submitterEmail\":\"authorized1@org1\",\"approvalTimeoutInSeconds\":3600,\"numberOfDispositionsRequired\":1,\"numberOfApprovalsReceived\":0,\"numberOfDeniesReceived\":0,\"programVersion\":null,\"details\":{\"type\":\"WithdrawalRequest\",\"account\":{\"identifier\":\"a7c36ae6-7ccf-4051-937b-4dfa34a29736\",\"name\":\"Bitcoin Wallet 1\",\"accountType\":\"BalanceAccount\",\"address\":\"mxUpwv18LoZWg6k7ksGoj3r8geruTcwqZq\"},\"symbolAndAmountInfo\":{\"symbolInfo\":{\"symbol\":\"BTC\",\"symbolDescription\":\"Bitcoin\",\"imageUrl\":\"https://s3.us-east-1.amazonaws.com/strike-public-assets/logos/BTC.png\"},\"amount\":\"0.50010380\",\"nativeAmount\":\"0.50010380\",\"usdEquivalent\":\"31581.55\"},\"destination\":{\"name\":\"Bitcoin Wallet 2\",\"address\":\"mwRPxwxTS9YD2bkUAqKYcHCPMpUoMemhPo\"},\"signingData\":{\"type\":\"bitcoin\",\"childKeyIndex\":0,\"transaction\":{\"version\":1,\"txIns\":[{\"txId\":\"81788c968daae8c6ea30a5041f283a798ad5ab253cb99ef2f0d0b167f937dd77\",\"index\":1,\"amount\":20000000,\"inputScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"base64HashForSignature\":\"OdGGt+Yh9Fp1wjHVGwpbmVJnjWOdFnZpeC+F9l+HG8g=\"},{\"txId\":\"5b4f03ab2e30fc4b716d4aefc47a6db59cdfca0a788068ce5131278e9d9f3d33\",\"index\":1,\"amount\":20000000,\"inputScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"base64HashForSignature\":\"AnxjVJFcoqK4y3URV/UMI4F9jIER5bb2cDI+TtkMtMc=\"},{\"txId\":\"bb149f176978a86e83ab12a7aee4c21fd5830963d89af74064762c4f023d35ea\",\"index\":1,\"amount\":20000000,\"inputScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"base64HashForSignature\":\"m73uZw7PDXkA5VzKxDEqdT+AMT2vwGvVcjzlRyd4a6E=\"}],\"txOuts\":[{\"index\":0,\"amount\":50000000,\"pubKeyScriptHex\":\"76A914AE74F20C5186F642F1396917DECF8246CEFDD13588AC\",\"address\":\"mwRPxwxTS9YD2bkUAqKYcHCPMpUoMemhPo\",\"isChange\":false},{\"index\":1,\"amount\":9989620,\"pubKeyScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"address\":\"mxUpwv18LoZWg6k7ksGoj3r8geruTcwqZq\",\"isChange\":true}],\"totalFee\":10380}}},\"vaultName\":\"Test Organization 1\"}\n"
+        let approvalData = "{\"id\":\"77475988-fd42-41c0-8ef6-cba19c1b1251\",\"submitDate\":\"2022-09-28T22:58:12.035+00:00\",\"submitterName\":\"User 1\",\"submitterEmail\":\"authorized1@org1\",\"approvalTimeoutInSeconds\":3600,\"numberOfDispositionsRequired\":1,\"numberOfApprovalsReceived\":0,\"numberOfDeniesReceived\":0,\"details\":{\"type\":\"WithdrawalRequest\",\"account\":{\"identifier\":\"a7c36ae6-7ccf-4051-937b-4dfa34a29736\",\"name\":\"Bitcoin Wallet 1\",\"accountType\":\"BalanceAccount\",\"address\":\"mxUpwv18LoZWg6k7ksGoj3r8geruTcwqZq\"},\"symbolAndAmountInfo\":{\"symbolInfo\":{\"symbol\":\"BTC\",\"symbolDescription\":\"Bitcoin\",\"imageUrl\":\"https://s3.us-east-1.amazonaws.com/strike-public-assets/logos/BTC.png\"},\"amount\":\"0.50010380\",\"nativeAmount\":\"0.50010380\",\"usdEquivalent\":\"31581.55\"},\"destination\":{\"name\":\"Bitcoin Wallet 2\",\"address\":\"mwRPxwxTS9YD2bkUAqKYcHCPMpUoMemhPo\"},\"signingData\":{\"type\":\"bitcoin\",\"childKeyIndex\":0,\"transaction\":{\"version\":1,\"txIns\":[{\"txId\":\"81788c968daae8c6ea30a5041f283a798ad5ab253cb99ef2f0d0b167f937dd77\",\"index\":1,\"amount\":20000000,\"inputScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"base64HashForSignature\":\"OdGGt+Yh9Fp1wjHVGwpbmVJnjWOdFnZpeC+F9l+HG8g=\"},{\"txId\":\"5b4f03ab2e30fc4b716d4aefc47a6db59cdfca0a788068ce5131278e9d9f3d33\",\"index\":1,\"amount\":20000000,\"inputScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"base64HashForSignature\":\"AnxjVJFcoqK4y3URV/UMI4F9jIER5bb2cDI+TtkMtMc=\"},{\"txId\":\"bb149f176978a86e83ab12a7aee4c21fd5830963d89af74064762c4f023d35ea\",\"index\":1,\"amount\":20000000,\"inputScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"base64HashForSignature\":\"m73uZw7PDXkA5VzKxDEqdT+AMT2vwGvVcjzlRyd4a6E=\"}],\"txOuts\":[{\"index\":0,\"amount\":50000000,\"pubKeyScriptHex\":\"76A914AE74F20C5186F642F1396917DECF8246CEFDD13588AC\",\"address\":\"mwRPxwxTS9YD2bkUAqKYcHCPMpUoMemhPo\",\"isChange\":false},{\"index\":1,\"amount\":9989620,\"pubKeyScriptHex\":\"76A914BA132C598CAA68EDEE903578AE11B6B03BFDC78588AC\",\"address\":\"mxUpwv18LoZWg6k7ksGoj3r8geruTcwqZq\",\"isChange\":true}],\"totalFee\":10380}}},\"vaultName\":\"Test Organization 1\"}\n"
         
-        let request: WalletApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
+        let request: ApprovalRequest = Mock.decodeJsonType(data: approvalData.data(using: .utf8)!)
         
         let approvalRequest = StrikeApi.ApprovalDispositionRequest(
             disposition: .Approve,
@@ -837,7 +833,7 @@ class StrikeTests: XCTestCase {
 
     }
     
-    func getOpAccountCreationInfo(_ request: WalletApprovalRequest) -> MultisigOpInitiation? {
+    func getOpAccountCreationInfo(_ request: ApprovalRequest) -> MultisigOpInitiation? {
         switch request.details {
         case .multisigOpInitiation(let initiation, _):
             return MultisigOpInitiation(opAccountCreationInfo: initiation.opAccountCreationInfo, initiatorIsApprover: initiation.initiatorIsApprover)


### PR DESCRIPTION
- Bitcoin and Ethereum wallet creation is approved by signing approval request details with respective Secp256k1 key
- `BalanceAccountCreation` approval type was renamed to `WalletCreation`
- `wallet-approvals` endpoint was renamed to `approval-requests`
- `programVersion` and `walletType` fields were removed from the `ApprovalRequest` model